### PR TITLE
wording

### DIFF
--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -12,19 +12,22 @@ msgstr ""
 "Language: \n"
 
 msgid "plugins.generic.pidManager.displayName"
-msgstr "PID Manager Plugin"
+msgstr "PID Manager"
 
 msgid "plugins.generic.pidManager.description"
-msgstr "Plugin for managing Persistent Identifiers (PIDs) and depositing to external services."
+msgstr "Plugin for adding Persistent Identifiers (PIDs) to publications."
 
 msgid "plugins.generic.pidManager.settings.title"
-msgstr "Enable PIDs by selecting below"
+msgstr "Manage PIDs"
+
+msgid "plugins.generic.pidManager.settings.description"
+msgstr "Use the following checkboxes to select which Persistent Identifiers (PIDs) can be added during the editorial process and made visible in the article view. Ticking a box activates the corresponding PID type."
 
 msgid "plugins.generic.pidManager.settings.igsn.label"
-msgstr "Enable IGSN"
+msgstr "IGSN (International Generic Sample Number - <a href=\"https://igsn.org\" target=\"_blank\">igsn.org</a>)"
 
 msgid "plugins.generic.pidManager.settings.pidinst.label"
-msgstr "Enable PIDINST"
+msgstr "PIDINST (Persistent Identification of Instruments - <a href=\"https://pidinst.org\" target=\"_blank\">pidinst.org</a>)"
 
 msgid "plugins.generic.pidManager.igsn.label"
 msgstr "International Generic Sample Number (IGSN)"
@@ -35,29 +38,28 @@ msgstr "IGSN"
 msgid "plugins.generic.pidManager.igsn.workflow.label"
 msgstr "IGSN"
 
-msgid "plugins.generic.pidManager.igsn.workflow.description"
+msgid "plugins.generic.pidManager.igsn.workflow.instructions"
 msgstr ""
-"The International Generic Sample Number (IGSN) is a persistent identifier, which is a code "
-"that uniquely identifies physical samples from our natural environment and related features-of-interest. "
-"Learn more at <a href=\"https://igsn.org\" target=\"_blank\">igsn.org</a>.<br/>"
-"If you want to search for an IGSN, fill your search phrase at DOI and or Label and click on the search button."
+"Here you can add existing IGSNs to the publication. "
+"Use the upper table to look up the IGSN that you want to add. Enter the DOI or title of the IGSN. Start the search by clicking the search button and select one of the suggested IGSNs; autocomplete will assist you. You can select multiple IGSNs in one search and close the suggestions by clicking the 'x' button. Greyed-out suggestions have already been added.<br>"
+"The lower table shows the available metadata for the IGSNs you added. These properties will also be displayed in the article view. You can manually add an IGSN and edit the metadata values."
 
-msgid "plugins.generic.pidManager.igsn.submission.description"
+msgid "plugins.generic.pidManager.igsn.generalDescription"
 msgstr ""
-"The International Generic Sample Number (IGSN) is a persistent identifier, which is a code "
-"that uniquely identifies physical samples from our natural environment and related features-of-interest. "
+"The International Generic Sample Number (IGSN) is a unique, persistent, domain-agnositc identifier for material samples. These samples can be any material from all disciplines in the universe. "
 "Learn more at <a href=\"https://igsn.org\" target=\"_blank\">igsn.org</a>.<br>"
-"The IGSNs can be entered later by the journal manager or another authorised user. "
-"Unfortunately, this cannot be done by the author."
+
+msgid "plugins.generic.pidManager.igsn.submission.instructions"
+msgstr "Currently, IGSNs can only be set at a later stage in the editorial process. Please contact the journal manager if you would like to add a IGSN to your publication. For future versions of the PID Manager, it is planned to make IGSNs addable in the submission wizard."
 
 msgid "plugins.generic.pidManager.igsn.workflow.empty"
-msgstr "There are no IGSNs found for this publication."
+msgstr "Yet, no IGSNs have been added to this publication."
 
 msgid "plugins.generic.pidManager.igsn.workflow.table.pid"
 msgstr "DOI"
 
-msgid "plugins.generic.pidManager.igsn.workflow.table.label"
-msgstr "Label"
+msgid "plugins.generic.pidManager.igsn.workflow.table.title"
+msgstr "Title"
 
 msgid "plugins.generic.pidManager.igsn.workflow.table.creators"
 msgstr "Creators"
@@ -77,8 +79,11 @@ msgstr "Are you sure you want to remove?"
 msgid "plugins.generic.pidManager.igsn.datacite.searchPhraseDoi.placeholder"
 msgstr "Type your DOI here, e.g. 10.12345/12.3456"
 
-msgid "plugins.generic.pidManager.igsn.datacite.searchPhraseLabel.placeholder"
-msgstr "Type your label here, e.g. Sediment core"
+msgid "plugins.generic.pidManager.igsn.datacite.searchPhraseTitle.placeholder"
+msgstr "Type your title here, e.g. Sediment core"
+
+msgid "plugins.generic.pidManager.igsn.articleDetails.details"
+msgstr "The following list shows the IGSNs linked to the publication."
 
 msgid "plugins.generic.pidManager.igsn.datacite.info"
 msgstr "Please type your search phrase above and search on DataCite."
@@ -88,6 +93,8 @@ msgstr "Your search phrase returned empty."
 
 
 msgid "plugins.generic.pidManager.pidinst.label"
+msgstr "Persistent Identification of Instruments (PIDINST)"
+
 msgstr "International Generic Sample Number (Pidinst)"
 
 msgid "plugins.generic.pidManager.pidinst.workflow.name"
@@ -96,29 +103,35 @@ msgstr "PIDINST"
 msgid "plugins.generic.pidManager.pidinst.workflow.label"
 msgstr "PIDINST"
 
-msgid "plugins.generic.pidManager.pidinst.workflow.description"
-msgstr ""
-"The International Generic Sample Number (PIDINST) is a persistent identifier, which is a code "
-"that uniquely identifies physical samples from our natural environment and related features-of-interest. "
-"Learn more at <a href=\"https://pidinst.org\" target=\"_blank\">pidinst.org</a>.<br/>"
-"If you want to search for an PIDINST, fill your search phrase at DOI and or Label and click on the search button."
 
-msgid "plugins.generic.pidManager.pidinst.submission.description"
+
+
+
+msgid "plugins.generic.pidManager.pidinst.workflow.instructions"
 msgstr ""
-"The International Generic Sample Number (PIDINST) is a persistent identifier, which is a code "
-"that uniquely identifies physical samples from our natural environment and related features-of-interest. "
-"Learn more at <a href=\"https://pidinst.org\" target=\"_blank\">pidinst.org</a>.<br>"
-"The PIDINSTs can be entered later by the journal manager or another authorised user. "
-"Unfortunately, this cannot be done by the author."
+"Here you can add existing PIDINSTs to the publication. "
+"Use the upper table to look up the PIDINST that you want to add. Enter the DOI or title of the PIDINST. Start the search by clicking the search button and select one of the suggested PIDINSTs; autocomplete will assist you. You can select multiple PIDINSTs in one search and close the suggestions by clicking the 'x' button. Greyed-out suggestions have already been added.<br>"
+"The lower table shows the available metadata for the PIDINSTs you added. These properties will also be displayed in the article view. You can manually add an PIDINST and edit the metadata values."
+
+
+
+
+msgid "plugins.generic.pidManager.pidinst.generalDescription"
+msgstr ""
+"The Persistent Identifier for Instruments (PIDINST) is a globally unique identifier for measuring instruments operted in the sciences. "
+"Learn more at <a href=\"https://pidinst.org\" target=\"_blank\">pidinst.org</a>.<br/>"
+
+msgid "plugins.generic.pidManager.pidinst.submission.instructions"
+msgstr "Currently, PIDINSTs can only be set at a later stage in the editorial process. Please contact the journal manager if you would like to add a PIDINST to your publication. For future versions of the PID Manager, it is planned to make PIDINSTs addable in the submission wizard."
 
 msgid "plugins.generic.pidManager.pidinst.workflow.empty"
-msgstr "There are no PIDINSTs found for this publication."
+msgstr "Yet, no PIDINSTs have been added to this publication."
 
 msgid "plugins.generic.pidManager.pidinst.workflow.table.pid"
 msgstr "DOI"
 
-msgid "plugins.generic.pidManager.pidinst.workflow.table.label"
-msgstr "Label"
+msgid "plugins.generic.pidManager.pidinst.workflow.table.title"
+msgstr "Title"
 
 msgid "plugins.generic.pidManager.pidinst.workflow.table.creators"
 msgstr "Creators"
@@ -138,8 +151,11 @@ msgstr "Are you sure you want to remove?"
 msgid "plugins.generic.pidManager.pidinst.datacite.searchPhraseDoi.placeholder"
 msgstr "Type your DOI here, e.g. 10.12345/12.3456"
 
-msgid "plugins.generic.pidManager.pidinst.datacite.searchPhraseLabel.placeholder"
-msgstr "Type your label here, e.g. Sediment core"
+msgid "plugins.generic.pidManager.pidinst.datacite.searchPhraseTitle.placeholder"
+msgstr "Type your title here, e.g. station"
+
+msgid "plugins.generic.pidManager.pidinst.articleDetails.details"
+msgstr "The following list shows the PIDINSTs linked to the publication."
 
 msgid "plugins.generic.pidManager.pidinst.datacite.info"
 msgstr "Please type your search phrase above and search on DataCite."

--- a/templates/igsn/articleDetails.tpl
+++ b/templates/igsn/articleDetails.tpl
@@ -13,7 +13,11 @@
         <h2 class="label">
             {translate key="plugins.generic.pidManager.{$pidName}.label"}
         </h2>
-        <div class="value">
+        <p align="justify" class="description" style="color: rgba(0,0,0,0.54)">
+            {translate key="plugins.generic.pidManager.{$pidName}.generalDescription"}
+            {translate key="plugins.generic.pidManager.{$pidName}.articleDetails.details"}
+        </p>
+        <div class="value"> 
             {foreach from=$items item="item"}
                 <p>
                     {if $item->creators}{$item->creators}. {/if}

--- a/templates/igsn/submissionWizard.tpl
+++ b/templates/igsn/submissionWizard.tpl
@@ -12,7 +12,8 @@
     <label class="label">
         {translate key="plugins.generic.pidManager.{$pidName}.label"}
     </label>
-    <p>
-        {translate key="plugins.generic.pidManager.{$pidName}.submission.description"}
+    <p align="justify" class="description">
+        <i>{translate key="plugins.generic.pidManager.{$pidName}.generalDescription"}
+        {translate key="plugins.generic.pidManager.{$pidName}.submission.instructions"}</i>
     </p>
 </div>

--- a/templates/igsn/workflow.tpl
+++ b/templates/igsn/workflow.tpl
@@ -16,9 +16,15 @@
 
     <link rel="stylesheet" href="{$assetsUrl}/css/backend.css" type="text/css"/>
 
-    <div class="header">
-        <h4 class="mt-0">{translate key="plugins.generic.pidManager.{$pidName}.workflow.label"}</h4>
-        <span>{translate key="plugins.generic.pidManager.{$pidName}.workflow.description"}</span>
+    <div class="pkpFormField__heading">
+        <label class="pkpFormFieldLabel">
+            {translate key="plugins.generic.pidManager.{$pidName}.workflow.label"}
+        </label>
+    </div>
+    <div class="pkpFormField__description">
+        {translate key="plugins.generic.pidManager.{$pidName}.generalDescription"}
+        <br>
+        {translate key="plugins.generic.pidManager.{$pidName}.workflow.instructions"}       
     </div>
 
     <div class="content">
@@ -31,7 +37,7 @@
                 </th>
                 <th>
                     <span class="block">
-                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.label"}
+                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.title"}
                     </span>
                 </th>
                 <th class="center w-42">
@@ -46,9 +52,9 @@
                     />
                 </td>
                 <td>
-                    <input v-model="pidManagerApp{$pidName}.searchPhraseLabel" type="text"
+                    <input v-model="pidManagerApp{$pidName}.searchPhraseTitle" type="text"
                            class="pkpFormField__input pkpFormField--text__input"
-                           placeholder="{translate key="plugins.generic.pidManager.{$pidName}.datacite.searchPhraseLabel.placeholder"}"
+                           placeholder="{translate key="plugins.generic.pidManager.{$pidName}.datacite.searchPhraseTitle.placeholder"}"
                     />
                 </td>
                 <td class="center w-42">
@@ -109,7 +115,7 @@
                 </th>
                 <th>
                     <span class="block">
-                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.label"}
+                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.title"}
                     </span>
                 </th>
                 <th>
@@ -189,7 +195,7 @@
                     items: {$items},
                     dataModel: {$dataModel},
                     searchPhraseDoi: '',
-                    searchPhraseLabel: '',
+                    searchPhraseTitle: '',
                     searchResults: [], // [ { 'id': '', 'label': '' }, ... ]
                     panelVisibility: { /**/ empty: false, spinner: false, list: false},
                     panelVisibilityDefault: { /**/ empty: false, spinner: false, list: false},
@@ -262,7 +268,7 @@
                 },
                 clearSearch: function () {
                     this.searchPhraseDoi = '';
-                    this.searchPhraseLabel = '';
+                    this.searchPhraseTitle = '';
                     this.searchResults = [];
                     this.panelVisibilityReset();
                     this.stopPendingRequests();
@@ -291,7 +297,7 @@
                 },
                 apiLookup: function () {
                     if (this.searchPhraseDoi.length < this.minimumSearchPhraseLength &&
-                        this.searchPhraseLabel.length < this.minimumSearchPhraseLength
+                        this.searchPhraseTitle.length < this.minimumSearchPhraseLength
                     ) {
                         return;
                     }
@@ -299,8 +305,8 @@
                     if (this.searchPhraseDoi.length >= this.minimumSearchPhraseLength) {
                         query += ' AND id:' + this.getDoiCleaned(this.searchPhraseDoi);
                     }
-                    if (this.searchPhraseLabel.length >= this.minimumSearchPhraseLength) {
-                        query += ' AND titles.title:' + this.getLabelCleaned(this.searchPhraseLabel);
+                    if (this.searchPhraseTitle.length >= this.minimumSearchPhraseLength) {
+                        query += ' AND titles.title:' + this.getLabelCleaned(this.searchPhraseTitle);
                     }
                     if (query.length === 0) return;
 

--- a/templates/pidinst/articleDetails.tpl
+++ b/templates/pidinst/articleDetails.tpl
@@ -13,6 +13,10 @@
         <h2 class="label">
             {translate key="plugins.generic.pidManager.{$pidName}.label"}
         </h2>
+        <p align="justify" class="description" style="color: rgba(0,0,0,0.54)">
+            {translate key="plugins.generic.pidManager.{$pidName}.generalDescription"}
+            {translate key="plugins.generic.pidManager.{$pidName}.articleDetails.details"}
+        </p>
         <div class="value">
             {foreach from=$items item="item"}
                 <p>

--- a/templates/pidinst/submissionWizard.tpl
+++ b/templates/pidinst/submissionWizard.tpl
@@ -12,7 +12,8 @@
     <label class="label">
         {translate key="plugins.generic.pidManager.{$pidName}.label"}
     </label>
-    <p>
-        {translate key="plugins.generic.pidManager.{$pidName}.submission.description"}
+    <p align="justify" class="description">
+        <i>{translate key="plugins.generic.pidManager.{$pidName}.generalDescription"}
+        {translate key="plugins.generic.pidManager.{$pidName}.submission.instructions"}</i>
     </p>
 </div>

--- a/templates/pidinst/workflow.tpl
+++ b/templates/pidinst/workflow.tpl
@@ -16,9 +16,15 @@
 
     <link rel="stylesheet" href="{$assetsUrl}/css/backend.css" type="text/css"/>
 
-    <div class="header">
-        <h4 class="mt-0">{translate key="plugins.generic.pidManager.{$pidName}.workflow.label"}</h4>
-        <span>{translate key="plugins.generic.pidManager.{$pidName}.workflow.description"}</span>
+    <div class="pkpFormField__heading">
+        <label class="pkpFormFieldLabel">
+            {translate key="plugins.generic.pidManager.{$pidName}.workflow.label"}
+        </label>
+    </div>
+    <div class="pkpFormField__description">
+        {translate key="plugins.generic.pidManager.{$pidName}.generalDescription"}
+        <br>
+        {translate key="plugins.generic.pidManager.{$pidName}.workflow.instructions"}       
     </div>
 
     <div class="content">
@@ -31,7 +37,7 @@
                 </th>
                 <th>
                     <span class="block">
-                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.label"}
+                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.title"}
                     </span>
                 </th>
                 <th class="center w-42">
@@ -46,9 +52,9 @@
                     />
                 </td>
                 <td>
-                    <input v-model="pidManagerApp{$pidName}.searchPhraseLabel" type="text"
+                    <input v-model="pidManagerApp{$pidName}.searchPhraseTitle" type="text"
                            class="pkpFormField__input pkpFormField--text__input"
-                           placeholder="{translate key="plugins.generic.pidManager.{$pidName}.datacite.searchPhraseLabel.placeholder"}"
+                           placeholder="{translate key="plugins.generic.pidManager.{$pidName}.datacite.searchPhraseTitle.placeholder"}"
                     />
                 </td>
                 <td class="center w-42">
@@ -109,7 +115,7 @@
                 </th>
                 <th>
                     <span class="block">
-                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.label"}
+                        {translate key="plugins.generic.pidManager.{$pidName}.workflow.table.title"}
                     </span>
                 </th>
                 <th>
@@ -189,7 +195,7 @@
                     items: {$items},
                     dataModel: {$dataModel},
                     searchPhraseDoi: '',
-                    searchPhraseLabel: '',
+                    searchPhraseTitle: '',
                     searchResults: [], // [ { 'id': '', 'label': '' }, ... ]
                     panelVisibility: { /**/ empty: false, spinner: false, list: false},
                     panelVisibilityDefault: { /**/ empty: false, spinner: false, list: false},
@@ -262,7 +268,7 @@
                 },
                 clearSearch: function () {
                     this.searchPhraseDoi = '';
-                    this.searchPhraseLabel = '';
+                    this.searchPhraseTitle = '';
                     this.searchResults = [];
                     this.panelVisibilityReset();
                     this.stopPendingRequests();
@@ -291,7 +297,7 @@
                 },
                 apiLookup: function () {
                     if (this.searchPhraseDoi.length < this.minimumSearchPhraseLength &&
-                        this.searchPhraseLabel.length < this.minimumSearchPhraseLength
+                        this.searchPhraseTitle.length < this.minimumSearchPhraseLength
                     ) {
                         return;
                     }
@@ -299,8 +305,8 @@
                     if (this.searchPhraseDoi.length >= this.minimumSearchPhraseLength) {
                         query += ' AND id:' + this.getDoiCleaned(this.searchPhraseDoi);
                     }
-                    if (this.searchPhraseLabel.length >= this.minimumSearchPhraseLength) {
-                        query += ' AND titles.title:' + this.getLabelCleaned(this.searchPhraseLabel);
+                    if (this.searchPhraseTitle.length >= this.minimumSearchPhraseLength) {
+                        query += ' AND titles.title:' + this.getLabelCleaned(this.searchPhraseTitle);
                     }
                     if (query.length === 0) return;
 

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -24,18 +24,20 @@
     {fbvFormSection
     for="{APP\plugins\generic\pidManager\classes\Constants::settingEnableIgsn}"
     title="plugins.generic.pidManager.settings.title" list="true"}
+    <p align="justify" class="description" style="color: rgba(0,0,0,0.54)">
+        {translate key="plugins.generic.pidManager.settings.description"}
+        {fbvElement
+        type="checkbox"
+        id="{APP\plugins\generic\pidManager\classes\Constants::settingEnableIgsn}"
+        checked=${APP\plugins\generic\pidManager\classes\Constants::settingEnableIgsn}
+        label="plugins.generic.pidManager.settings.igsn.label"}
 
-    {fbvElement
-    type="checkbox"
-    id="{APP\plugins\generic\pidManager\classes\Constants::settingEnableIgsn}"
-    checked=${APP\plugins\generic\pidManager\classes\Constants::settingEnableIgsn}
-    label="plugins.generic.pidManager.settings.igsn.label"}
-
-    {fbvElement
-    type="checkbox"
-    id="{APP\plugins\generic\pidManager\classes\Constants::settingEnablePidinst}"
-    checked=${APP\plugins\generic\pidManager\classes\Constants::settingEnablePidinst}
-    label="plugins.generic.pidManager.settings.pidinst.label"}
+        {fbvElement
+        type="checkbox"
+        id="{APP\plugins\generic\pidManager\classes\Constants::settingEnablePidinst}"
+        checked=${APP\plugins\generic\pidManager\classes\Constants::settingEnablePidinst}
+        label="plugins.generic.pidManager.settings.pidinst.label"}
+    </p>
 
     {/fbvFormSection}
 


### PR DESCRIPTION
This pull requests includes several changes concerning the wording of the PID Manager including the plugin settings, submission wizard, workflow and articleDetails. 

plugin settings: 
<img width="790" height="328" alt="Bildschirmfoto 2025-09-08 um 11 41 12" src="https://github.com/user-attachments/assets/c39b7a3e-ca3d-4a6d-a58e-be24b6dc368f" />

submission wizard: 
<img width="968" height="295" alt="Bildschirmfoto 2025-09-08 um 11 40 45" src="https://github.com/user-attachments/assets/50c95dc3-65b1-4e61-85cf-d447f72b8fd3" />

workflow: 
<img width="965" height="406" alt="Bildschirmfoto 2025-09-08 um 11 40 01" src="https://github.com/user-attachments/assets/925fcbb2-2a1a-4dca-a36f-29c53052a702" />
<img width="966" height="419" alt="Bildschirmfoto 2025-09-08 um 11 40 14" src="https://github.com/user-attachments/assets/2ee12073-d861-4ef9-ad34-159bce3c6a99" />

articleDetails: 
<img width="526" height="155" alt="Bildschirmfoto 2025-09-08 um 11 39 10" src="https://github.com/user-attachments/assets/1b4eb736-8d9f-437b-acf8-b713d0a57cbc" />
<img width="529" height="162" alt="Bildschirmfoto 2025-09-08 um 11 39 22" src="https://github.com/user-attachments/assets/6ca98625-859f-4b98-baa4-6f302fd6db2d" />
